### PR TITLE
add option to darken past weeks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,3 +90,12 @@ change the output filename with the ``-f`` option
     $> python generate_life_calendar.py "23/10/1990" -f my_life_calendar.pdf
 
     Created my_life_calendar.pdf
+
+If you would like to fill in the squares for past weeks but don't want to do
+this by hand, just pass the ``-d`` option to darken past weeks
+
+::
+
+    $> python generate_life_calendar.py "23/10/1990" -d
+
+    Created life_calendar.pdf


### PR DESCRIPTION
Hi!  I love this tool - I just found it and printed a calendar for myself.  But since I plan to fill in the weeks as they pass, I wanted the past weeks to be filled-in.  For we-the-lazy, it seems the generate script should have an option to do this for you.

I tested this by creating a calendar without and with the new flag.  Resulting PDFs are below, respectively.
[no_flag.pdf](https://github.com/eriknyquist/generate_life_calendar/files/7629943/no_flag.pdf)
[flag.pdf](https://github.com/eriknyquist/generate_life_calendar/files/7629942/flag.pdf)
